### PR TITLE
Fix crash when calling appUserId, isAnonymous and syncPurchases

### DIFF
--- a/source/Purchases.brs
+++ b/source/Purchases.brs
@@ -629,10 +629,10 @@ function _InternalPurchases(o = {} as object) as object
         setUserId: function(userId as string) as void
             m.identityManager.setUserId(userId)
         end function,
-        appUserId: function() as string
+        appUserId: function(inputArgs = {}) as string
             return m.identityManager.appUserId()
         end function,
-        isAnonymous: function() as boolean
+        isAnonymous: function(inputArgs = {}) as boolean
             return m.identityManager.isAnonymous()
         end function,
         logIn: function(userId as string) as object
@@ -760,7 +760,7 @@ function _InternalPurchases(o = {} as object) as object
                 }
             }
         end function,
-        syncPurchases: function() as object
+        syncPurchases: function(inputArgs = {}) as object
             m.configuration.assert()
             result = m.billing.getAllPurchases()
             if result.error <> invalid


### PR DESCRIPTION
Methods in the internal class need to have one parameter even if it's unused as invokeMethod always invokes passing one parameter.