### PR TITLE
Add Roku SDK contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ If lint or format checks fail before your change, report the exact pre-existing 
 ## BrightScript Notes
 
 - `invalid` is the null-like value. Check it explicitly before indexing nested associative arrays.
-- Associative arrays and arrays are mutable. Use `_deepCopy()` when adding targeting context to offerings that should not mutate the original object.
+- Associative arrays and arrays are mutable. Use the internal `m._deepCopy()` helper when adding targeting context to offerings that should not mutate the original object.
 - Callback APIs support both anonymous functions and callback function names. Preserve both `roFunction`/`Function` and `roString`/`String` paths.
 - BrightScript identifiers are easy to shadow in surprising ways. Be careful when renaming parameters or local variables, especially near scoped functions.
 - Date values exposed by the SDK are `roDateTime` objects created from RevenueCat ISO 8601 strings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Agent Guidance
+
+This repository is the RevenueCat SDK for Roku. It is small, but the runtime model is unusual if you are coming from web, mobile, or server SDKs. Read this before making code changes.
+
+## Project Map
+
+- `source/Purchases.brs` contains the public `Purchases()` singleton, configuration, identity, network, billing orchestration, model mapping, and most test seams.
+- `components/purchases/PurchasesTask.xml` and `components/purchases/PurchasesTask.brs` define the SceneGraph `Task` used for async work.
+- `source/main.brs` starts the sample channel, or runs tests when the manifest compile-time flag sets `runTests=true`.
+- `source/tests/**` contains the local test suite, fixtures, mocked API/billing implementations, and the vendored `roca` test helpers.
+- `scripts/runLocal.sh` stages the channel, toggles `runTests=true`, zips it, and runs it with `brs-engine`.
+- `scripts/runDevice.sh` and `scripts/deploy.js` deploy to a physical Roku using `.env` values.
+- `docs/architecture.md` explains the Roku/BrightScript constraints behind this structure.
+
+## Common Commands
+
+Use Corepack because `package.json` declares Yarn 1:
+
+```sh
+corepack yarn install --frozen-lockfile
+corepack yarn tests
+corepack yarn lint
+corepack yarn checkFormat
+corepack yarn format
+```
+
+Device testing requires a `.env` file with `ROKU_IP_ADDRESS` and `ROKU_PASSWORD`:
+
+```sh
+corepack yarn deviceTests
+corepack yarn device
+```
+
+If lint or format checks fail before your change, report the exact pre-existing failures instead of mixing broad cleanup into an unrelated patch.
+
+## Roku Runtime Rules
+
+- Public SDK calls are intended for SceneGraph component code. Do not move normal SDK usage into `source/main.brs` or into arbitrary task components.
+- Blocking or platform operations such as network requests and `roChannelStore` billing must stay behind the `PurchasesTask` flow or test doubles.
+- The render thread and task thread communicate through SceneGraph node fields. Preserve the `api` field request path and callback-field response path unless you are intentionally redesigning threading.
+- `m.global` is available in SceneGraph components, while tests run from the main thread. Keep `_InternalPurchases_GetPurchasesConfig()` and `_InternalPurchases_SetPurchasesConfig()` behavior compatible with both modes.
+
+## BrightScript Notes
+
+- `invalid` is the null-like value. Check it explicitly before indexing nested associative arrays.
+- Associative arrays and arrays are mutable. Use `_deepCopy()` when adding targeting context to offerings that should not mutate the original object.
+- Callback APIs support both anonymous functions and callback function names. Preserve both `roFunction`/`Function` and `roString`/`String` paths.
+- BrightScript identifiers are easy to shadow in surprising ways. Be careful when renaming parameters or local variables, especially near scoped functions.
+- Date values exposed by the SDK are `roDateTime` objects created from RevenueCat ISO 8601 strings.
+- Use `1000&` style long-integer literals where large millisecond timestamps could overflow an integer.
+
+## RevenueCat SDK Behavior To Preserve
+
+- `Purchases()` is a singleton stored on `GetGlobalAA().rc_purchasesSingleton`.
+- Configuration stores the API key and optional proxy/log settings outside the registry; identity persists in the registry.
+- Registry storage is namespaced as `RevenueCat_` plus the Roku app ID. Keep legacy migration from the old `RevenueCat` section.
+- `logIn` and `logOut` call RevenueCat identify endpoints and update the stored app user ID.
+- `getOfferings` merges RevenueCat offerings with Roku catalog products from `roChannelStore`.
+- Purchases can be made by `code`, `product`, or `package`, and package purchases may carry presented offering, placement, and targeting context to the receipt endpoint.
+- Subscriber/customer info returned from RevenueCat is mapped to the public Roku SDK shape in `buildSubscriber`.
+
+## Testing Guidance
+
+- Local tests run with `brs-engine`; they do not exercise full SceneGraph rendering or real Roku billing.
+- Test mode sets `GetGlobalAA().isRunningRevenueCatTests = true` and routes public `Purchases()` calls to `GetGlobalAA().rc_internalTestPurchases`.
+- Prefer adding focused tests in the matching file under `source/tests`.
+- Use `configurePurchases()` to inject mocked API or billing behavior.
+- Use real device tests for changes involving `roChannelStore`, Task behavior, SceneGraph threading, or anything that `brs-engine` cannot faithfully simulate.
+
+## Documentation Guidance
+
+- Keep README examples focused on SDK consumers.
+- Put contributor/runtime explanations in `docs/architecture.md` or this file.
+- Avoid generic AI-assistant instructions. This file should document repo-specific constraints that prevent plausible but wrong changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,118 @@
+# Roku SDK Architecture
+
+This SDK is a BrightScript and SceneGraph implementation of the RevenueCat Purchases API for Roku channels. The important design constraint is that Roku apps do not behave like a single-threaded script with unrestricted APIs. SceneGraph rendering, BrightScript components, channel storage, billing, and network work all have thread and component restrictions.
+
+For Roku platform background, start with Roku's docs for [SceneGraph threading](https://developer.roku.com/en-gb/docs/developer-program/core-concepts/threads.md), [Task nodes](https://developer.roku.com/en-gb/docs/references/scenegraph/control-nodes/task.md), [BrightScript language concepts](https://developer.roku.com/en-gb/docs/references/brightscript/language/brightscript-language-reference.md), [`roRegistrySection`](https://developer.roku.com/en-gb/docs/references/brightscript/components/roregistrysection.md), [`roUrlTransfer`](https://developer.roku.com/en-gb/docs/references/brightscript/components/rourltransfer.md), and [`roChannelStore`](https://developer.roku.com/en-gb/docs/references/brightscript/components/rochannelstore.md).
+
+## File Layout
+
+- `source/Purchases.brs` is the SDK entry point and implementation. It defines the `Purchases()` singleton and internal helpers for configuration, registry access, identity, API calls, billing calls, offerings, purchase posting, subscriber mapping, logging, and HTTP fetches.
+- `components/purchases/PurchasesTask.xml` declares the SceneGraph `Task` interface fields: `api`, `response`, and `callbackID`.
+- `components/purchases/PurchasesTask.brs` starts the task run loop, observes incoming API requests, and writes results back to callback fields.
+- `source/tests/**` contains the test suite and mocks used by `brs-engine`.
+- `manifest` defines compile-time constants, including `runTests=false` by default.
+
+## Threading Model
+
+Roku SceneGraph apps have distinct execution contexts. The main BrightScript thread starts the app. The SceneGraph render thread owns UI component code. Task nodes run asynchronous work on separate task threads.
+
+This SDK expects app-facing calls to happen from SceneGraph components because `Purchases()` needs access to `m.global` and the active scene. Normal SDK calls should not be added to `source/main.brs`.
+
+The public singleton creates or finds a child `PurchasesTask` node with ID `purchasesTask`. Async SDK methods write an associative array to the task's `api` field:
+
+```brightscript
+{
+    method: "getOfferings",
+    args: {},
+    callbackID: "1"
+}
+```
+
+The task run loop receives the field event, invokes the internal method, and writes the result to the callback field on the task. The render-thread side observes that field and invokes either the anonymous callback function or named callback function supplied by the caller.
+
+## Configuration And Identity
+
+Configuration is not stored in the registry. The SDK stores runtime configuration in:
+
+- `GetGlobalAA().rc_purchasesConfig` during local tests, because tests run from the main thread.
+- `GetGlobalAA().global.rc_purchasesConfig` during normal SceneGraph execution, because the global node is shared between component and task contexts.
+
+Identity is persisted in the Roku registry. The registry section is namespaced with the Roku app ID:
+
+```brightscript
+sectionName = "RevenueCat_" + appInfo.GetID()
+```
+
+This avoids cross-app collisions for the same developer account. The registry helper also migrates old data from the legacy `RevenueCat` section.
+
+If no user ID has been configured or logged in, `appUserId()` generates and stores a RevenueCat anonymous user ID using the `$RCAnonymousID:` prefix.
+
+## Network And Billing Boundaries
+
+RevenueCat API calls use `_InternalPurchases_fetch()`, a small wrapper around `roUrlTransfer`. It returns an object with `status`, `ok`, `headers`, `text()`, `json()`, and `xml()` helpers.
+
+Roku billing uses `roChannelStore` through the internal `billing` object:
+
+- `purchase()` calls `SetOrder()` and `DoOrder()`.
+- `getAllPurchases()` syncs existing Roku purchases.
+- `getProductsById()` reads the Roku catalog and indexes products by `code`.
+
+Keep network and billing behavior injectable. Tests replace the real API and billing methods through `configurePurchases()`.
+
+## Offerings Flow
+
+`getOfferings()` fetches RevenueCat offerings, fetches the Roku catalog, and merges each RevenueCat package with its matching Roku store product. The public result has:
+
+- `current`: the current offering, with targeting context applied when available.
+- `all`: all offerings keyed by offering identifier.
+- Internal placement/targeting fields used by `currentOfferingForPlacement()`.
+
+Placement lookups should not mutate the original offerings in `all`. The SDK uses `_deepCopy()` before adding targeting and placement context.
+
+## Purchase Flow
+
+`purchase()` accepts one of these inputs:
+
+- `{ code: "product_id" }`
+- `{ product: offering.current.annual.storeProduct }`
+- `{ package: offering.current.annual }`
+
+It optionally accepts `action: "Upgrade"` or `action: "Downgrade"`.
+
+After Roku returns a transaction, the SDK posts the receipt to RevenueCat with:
+
+- `fetch_token` from the Roku `purchaseId`.
+- `app_user_id` from the current identity manager.
+- `product_id` from the Roku product code.
+- Price, trial, introductory pricing, and presented offering context when available.
+
+The public purchase result contains the raw Roku transaction and the mapped RevenueCat subscriber object.
+
+## Subscriber Mapping
+
+`buildSubscriber()` transforms RevenueCat subscriber JSON into the public Roku SDK model. It converts date strings to `roDateTime` and builds:
+
+- `entitlements.active`
+- `entitlements.all`
+- `activeSubscriptions`
+- `allPurchasedProductIds`
+- `allPurchaseDatesByProduct`
+- `allExpirationDatesByProduct`
+- `nonSubscriptionTransactions`
+- `latestExpirationDate`
+
+Be careful with lifetime purchases and non-subscription purchases. They may not have the same fields as subscriptions.
+
+## Local Tests
+
+`corepack yarn tests` runs `scripts/runLocal.sh`. That script stages the channel into `out/.staging`, rewrites the staged manifest to set `runTests=true`, zips the staged channel, and runs it with `brs-engine`.
+
+The test entry point is `source/tests/main.brs`. It sets:
+
+```brightscript
+GetGlobalAA().isRunningRevenueCatTests = true
+```
+
+In test mode, public `Purchases()` methods call the injected internal test object instead of crossing through the SceneGraph task. This lets tests exercise the public API surface while replacing network and Roku billing calls.
+
+Use physical Roku testing for changes that depend on real SceneGraph behavior, task scheduling, `roChannelStore`, or platform APIs that `brs-engine` only approximates.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ Keep network and billing behavior injectable. Tests replace the real API and bil
 - `all`: all offerings keyed by offering identifier.
 - Internal placement/targeting fields used by `currentOfferingForPlacement()`.
 
-Placement lookups should not mutate the original offerings in `all`. The SDK uses `_deepCopy()` before adding targeting and placement context.
+Placement lookups should not mutate the original offerings in `all`. The SDK uses the internal `m._deepCopy()` helper before adding targeting and placement context.
 
 ## Purchase Flow
 


### PR DESCRIPTION
## Summary
- Add repository guidance for contributors working on Roku/BrightScript code
- Document the SDK architecture, task/component boundaries, and Roku runtime constraints
- Capture testing expectations and public API compatibility notes

## Why
The Roku SDK has platform-specific constraints that are easy to miss when making changes: SceneGraph task boundaries, BrightScript syntax and runtime behavior, registry persistence, and the purchase/receipt flow. This documentation gives contributors a repo-local reference before editing the SDK.

## Validation
- Reviewed the new Markdown files for formatting and scope
- No automated tests run; documentation-only change