### PR TITLE
Add automatic purchase sync and receipt retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+### ✨ New Features
+- Added automatic best-effort purchase syncing after `Purchases().configure(...)`. This is enabled by default and can be disabled with `autoSyncPurchases: false`.
+- Added a persistent registry-backed retry queue for failed RevenueCat receipt posts. Queued receipt posts are retried on the next configure/auto-sync cycle and removed after a successful post.
+
+### 🐞 Bugfixes
+- `syncPurchases` now attempts every Roku purchase returned by the store instead of aborting after the first failed receipt post. Failed posts are queued for retry and returned in an aggregate error result.
+
 ## 0.0.5
 ### ✨ New Features
 - Added support for setting a user ID when configuring the SDK:

--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ Initialize the SDK with your api key. You typically do this inside the `init()` 
     Purchases().configure({
       "apiKey": "roku_XXXXX",
       "userId": "my_user_id" ' optional, will use an anonymous user id if not provided
+      "autoSyncPurchases": true ' optional, defaults to true
     })
   end sub
 ```
+
+By default, configuring the SDK will perform a best-effort `syncPurchases` in the background. This helps RevenueCat recover Roku purchases that were made outside the app or before the app had a chance to post receipts. Errors from this automatic sync are logged but do not block configuration. Failed receipt posts are stored locally and retried the next time the SDK is configured.
+
+Set `autoSyncPurchases` to `false` if your app needs to opt out and call `syncPurchases` manually.
 
 ## Callbacks and error handling
 
@@ -357,6 +362,7 @@ sub init()
   Purchases().configure({
       "apiKey": "roku_XXXXX",
       "userId": "my_user_id" ' optional, will use an anonymous user id if not provided
+      "autoSyncPurchases": true ' optional, defaults to true
   })
   ' Login the user
   Purchases().logIn(m.my_user_id, sub(subscriber, error)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchases-roku",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "main": "index.js",
   "repository": "https://github.com/RevenueCat/purchases-roku",
   "author": "RevenueCat, Inc.",

--- a/source/Purchases.brs
+++ b/source/Purchases.brs
@@ -24,14 +24,24 @@ function Purchases() as object
         identityManager = _InternalPurchases_IdentityManager({ registry: registry })
 
         GetGlobalAA().rc_purchasesSingleton = {
-            purchase: sub(inputArgs = {} as object, callbackFunc = invalid as dynamic)
-                m._internal.invoke("purchase", inputArgs, callbackFunc)
+            purchase: sub(inputArgs = {} as object, callback = invalid as dynamic)
+                m._internal.invoke("purchase", inputArgs, callback)
             end sub,
-            syncPurchases: sub(callbackFunc = invalid as dynamic)
-                m._internal.invoke("syncPurchases", {}, callbackFunc)
+            syncPurchases: sub(callback = invalid as dynamic)
+                m._internal.invoke("syncPurchases", {}, callback)
             end sub,
             configure: sub(inputArgs = {} as object)
                 m._internal.configuration.configure(inputArgs)
+                if m._internal.configuration.autoSyncPurchasesEnabled() then
+                    m._internal.invoke("autoSyncPurchases", {}, sub(result, error)
+                        if error <> invalid
+                            _PurchasesLogger().warn("Auto sync purchases failed")
+                            _PurchasesLogger().warn(error)
+                        else
+                            _PurchasesLogger().info("Auto sync purchases completed")
+                        end if
+                    end sub)
+                end if
             end sub,
             isConfigured: function() as boolean
                 return m._internal.configuration.isConfigured()
@@ -48,77 +58,77 @@ function Purchases() as object
             logLevel: function() as string
                 return _PurchasesLogger().logLevelString()
             end function,
-            isAnonymous: sub(callbackFunc = invalid as dynamic) as object
+            isAnonymous: sub(callback = invalid as dynamic) as object
                 isAnonymous = m._internal.identityManager.isAnonymous()
-                if callbackFunc <> invalid then
-                    callbackFunc(isAnonymous, invalid)
+                if callback <> invalid then
+                    callback(isAnonymous, invalid)
                 end if
                 return isAnonymous
             end sub,
-            appUserId: sub(callbackFunc = invalid as dynamic) as object
+            appUserId: sub(callback = invalid as dynamic) as object
                 appUserId = m._internal.identityManager.appUserId()
-                if callbackFunc <> invalid then
-                    callbackFunc(appUserId, invalid)
+                if callback <> invalid then
+                    callback(appUserId, invalid)
                 end if
                 return appUserId
             end sub,
-            logIn: sub(inputArgs = {} as object, callbackFunc = invalid as dynamic)
-                m._internal.invoke("logIn", inputArgs, callbackFunc)
+            logIn: sub(inputArgs = {} as object, callback = invalid as dynamic)
+                m._internal.invoke("logIn", inputArgs, callback)
             end sub,
-            logOut: sub(callbackFunc = invalid as dynamic)
-                m._internal.invoke("logOut", {}, callbackFunc)
+            logOut: sub(callback = invalid as dynamic)
+                m._internal.invoke("logOut", {}, callback)
             end sub,
-            getCustomerInfo: sub(callbackFunc = invalid as dynamic)
-                m._internal.invoke("getCustomerInfo", {}, callbackFunc)
+            getCustomerInfo: sub(callback = invalid as dynamic)
+                m._internal.invoke("getCustomerInfo", {}, callback)
             end sub,
-            setAttributes: sub(inputArgs = {} as object, callbackFunc = invalid as dynamic)
-                m._internal.invoke("setAttributes", inputArgs, callbackFunc)
+            setAttributes: sub(inputArgs = {} as object, callback = invalid as dynamic)
+                m._internal.invoke("setAttributes", inputArgs, callback)
             end sub,
-            getOfferings: sub(callbackFunc = invalid as dynamic)
-                m._internal.invoke("getOfferings", {}, callbackFunc)
+            getOfferings: sub(callback = invalid as dynamic)
+                m._internal.invoke("getOfferings", {}, callback)
             end sub,
-            currentOfferingForPlacement: sub(inputArgs = {} as object, callbackFunc = invalid as dynamic)
-                m._internal.invoke("currentOfferingForPlacement", inputArgs, callbackFunc)
+            currentOfferingForPlacement: sub(inputArgs = {} as object, callback = invalid as dynamic)
+                m._internal.invoke("currentOfferingForPlacement", inputArgs, callback)
             end sub,
             _internal: {
                 configuration: configuration,
                 identityManager: identityManager,
                 callbackContext: m.context,
-                setCallbackID: function(callbackFunc as dynamic) as string
+                setCallbackID: function(callback as dynamic) as string
                     m.task.callbackID++
                     if (m.task.callbackID >= 100000) then
                         m.task.callbackID = 1
                     end if
                     callbackID = m.task.callbackID.tostr()
                     m.task.addField(callbackID, "assocarray", false)
-                    valueType = type(callbackFunc)
+                    valueType = type(callback)
                     if valueType = "roFunction" or valueType = "Function" then
                         m.task.observeField(callbackID, "_InternalPurchases_invokeCallbackFunction")
-                        m.callbackContext[callbackID] = callbackFunc
+                        m.callbackContext[callbackID] = callback
                     else if valueType = "roString" or valueType = "String" then
-                        m.task.observeField(callbackID, callbackFunc)
+                        m.task.observeField(callbackID, callback)
                     else
                         m.task.observeField(callbackID, "")
                     end if
                     return callbackID
                 end function,
-                invoke: function(name as string, inputArgs = {}, callbackFunc = invalid as dynamic)
+                invoke: function(name as string, inputArgs = {}, callback = invalid as dynamic)
                     if GetGlobalAA().isRunningRevenueCatTests <> invalid
                         if GetGlobalAA().rc_internalTestPurchases = invalid then
                             throw "Purchases SDK not configured for testing"
                         end if
                         result = GetGlobalAA().rc_internalTestPurchases[name](inputArgs)
-                        valueType = type(callbackFunc)
+                        valueType = type(callback)
                         if valueType = "roFunction" or valueType = "Function" then
-                            callbackFunc(result.data, result.error)
+                            callback(result.data, result.error)
                         else if valueType = "roString" or valueType = "String" then
-                            m[callbackFunc](result.data, result.error)
+                            m[callback](result.data, result.error)
                         end if
                     else
                         m.task["api"] = {
                             method: name,
                             args: inputArgs,
-                            callbackID: m.setCallbackID(callbackFunc),
+                            callbackID: m.setCallbackID(callback),
                         }
                     end if
                 end function
@@ -176,11 +186,22 @@ function _InternalPurchases_Configuration(o = {} as object) as object
             m.set(config)
         end function,
         set: function(config as object) as void
+            currentConfig = m.get()
+            if config.apiKey = invalid then config.apiKey = currentConfig.apiKey
+            if config.logLevel = invalid then config.logLevel = currentConfig.logLevel
+            if config.proxyUrl = invalid then config.proxyUrl = currentConfig.proxyUrl
+            if config.autoSyncPurchases = invalid then config.autoSyncPurchases = currentConfig.autoSyncPurchases
             _InternalPurchases_SetPurchasesConfig({
                 apiKey: config.apiKey,
                 logLevel: config.logLevel,
                 proxyUrl: config.proxyUrl,
+                autoSyncPurchases: config.autoSyncPurchases,
             })
+        end function,
+        autoSyncPurchasesEnabled: function() as boolean
+            autoSyncPurchases = m.get().autoSyncPurchases
+            if autoSyncPurchases = invalid then return true
+            return autoSyncPurchases <> false
         end function,
         assert: function() as void
             if m.get().apiKey = invalid then
@@ -197,44 +218,44 @@ end function
 function _PurchasesLogger() as object
     if GetGlobalAA().rc_logger = invalid then
         GetGlobalAA().rc_logger = {
-        logLevel: function() as integer
-            level = _InternalPurchases_GetPurchasesConfig().logLevel
-            if level <> invalid and m.levels[level] <> invalid then return m.levels[level]
-            return m.levels.info
-        end function,
-        logLevelString: function() as string
-            level = m.logLevel()
-            for each key in m.levels
-                if m.levels[key] = level then return key
-            end for
-            return "info"
-        end function,
-        levels: {
-            error: 3,
-            warn: 2,
-            info: 1,
-            debug: 0,
-        }
-        error: function(message) as void
-            if m.logLevel() > m.levels.error then return
-            print("😿‼️  Error: " + m.convertToString(message))
-        end function,
-        info: function(message) as void
-            if m.logLevel() > m.levels.info then return
-            print("ℹ️  Info: " + m.convertToString(message))
-        end function,
-        warn: function(message) as void
-            if m.logLevel() > m.levels.warn then return
-            print("⚠️  Warning: " + message)m.convertToString(message)
-        end function,
-        debug: function(message) as void
-            if m.logLevel() > m.levels.debug then return
-            print("🐞 Debug: " + m.convertToString(message))
-        end function,
-        convertToString: function(message) as string
-            if type(message) = "roString" or type(message) = "String" then return message
-            return FormatJson(message)
-        end function,
+            logLevel: function() as integer
+                level = _InternalPurchases_GetPurchasesConfig().logLevel
+                if level <> invalid and m.levels[level] <> invalid then return m.levels[level]
+                return m.levels.info
+            end function,
+            logLevelString: function() as string
+                level = m.logLevel()
+                for each key in m.levels
+                    if m.levels[key] = level then return key
+                end for
+                return "info"
+            end function,
+            levels: {
+                error: 3,
+                warn: 2,
+                info: 1,
+                debug: 0,
+            }
+            error: function(message) as void
+                if m.logLevel() > m.levels.error then return
+                print("😿‼️  Error: " + m.convertToString(message))
+            end function,
+            info: function(message) as void
+                if m.logLevel() > m.levels.info then return
+                print("ℹ️  Info: " + m.convertToString(message))
+            end function,
+            warn: function(message) as void
+                if m.logLevel() > m.levels.warn then return
+                print("⚠️  Warning: " + m.convertToString(message))
+            end function,
+            debug: function(message) as void
+                if m.logLevel() > m.levels.debug then return
+                print("🐞 Debug: " + m.convertToString(message))
+            end function,
+            convertToString: function(message) as string
+                if type(message) = "roString" or type(message) = "String" then return message
+                return FormatJson(message)
+            end function,
         }
     end if
     return GetGlobalAA().rc_logger
@@ -244,7 +265,7 @@ function _InternalPurchases_AppInfo(o = {} as object) as object
     return {
         appInfo: CreateObject("roAppInfo")
         GetID: function()
-        return m.appInfo.GetID()
+            return m.appInfo.GetID()
         end function,
         IsDev: function()
             return m.appInfo.IsDev()
@@ -309,11 +330,71 @@ function _InternalPurchases_Registry(sectionName) as object
         setUserId: function(userId as string) as void
             m.set({ userId: userId })
         end function,
+        getQueuedReceiptPosts: function() as object
+            entries = m.get()
+            if entries.queuedReceiptPosts = invalid then return {}
+            if type(entries.queuedReceiptPosts) <> "roAssociativeArray" then return {}
+            return entries.queuedReceiptPosts
+        end function,
+        setQueuedReceiptPosts: function(queuedReceiptPosts as object) as void
+            m.set({ queuedReceiptPosts: queuedReceiptPosts })
+        end function,
+        queueReceiptPost: function(inputArgs as object) as void
+            queuedReceiptPosts = m.getQueuedReceiptPosts()
+            id = inputArgs.id
+            if id = invalid then id = CreateObject("roDeviceInfo").getRandomUUID()
+            existingEntry = queuedReceiptPosts[id]
+            attempts = 0
+            createdAtMs = CreateObject("roDateTime").AsSeconds() * 1000&
+            if existingEntry <> invalid
+                attempts = existingEntry.attempts
+                createdAtMs = existingEntry.createdAtMs
+            end if
+            queuedReceiptPosts[id] = {
+                version: 1,
+                id: id,
+                userId: inputArgs.userId,
+                transaction: inputArgs.transaction,
+                presentedOfferingContext: inputArgs.presentedOfferingContext,
+                attempts: attempts,
+                createdAtMs: createdAtMs,
+                lastAttemptAtMs: invalid,
+            }
+            m.setQueuedReceiptPosts(queuedReceiptPosts)
+        end function,
+        removeQueuedReceiptPost: function(id as string) as void
+            queuedReceiptPosts = m.getQueuedReceiptPosts()
+            if queuedReceiptPosts[id] <> invalid
+                queuedReceiptPosts.Delete(id)
+                m.setQueuedReceiptPosts(queuedReceiptPosts)
+            end if
+        end function,
+        updateQueuedReceiptPost: function(entry as object) as void
+            queuedReceiptPosts = m.getQueuedReceiptPosts()
+            queuedReceiptPosts[entry.id] = entry
+            m.setQueuedReceiptPosts(queuedReceiptPosts)
+        end function,
+        purgeExpiredQueuedReceiptPosts: function() as void
+            queuedReceiptPosts = m.getQueuedReceiptPosts()
+            nowMs = CreateObject("roDateTime").AsSeconds() * 1000&
+            ttlMs = 30& * 24& * 60& * 60& * 1000&
+            expiredIds = []
+            for each id in queuedReceiptPosts
+                entry = queuedReceiptPosts[id]
+                if entry.createdAtMs <> invalid and nowMs - entry.createdAtMs > ttlMs
+                    expiredIds.push(id)
+                end if
+            end for
+            for each id in expiredIds
+                queuedReceiptPosts.Delete(id)
+            end for
+            m.setQueuedReceiptPosts(queuedReceiptPosts)
+        end function,
     }
 end function
 
 function _InternalPurchases_IdentityManager(o = {} as object) as object
-    return  {
+    return {
         registry: o.registry,
         setUserId: function(userId as string) as void
             m.registry.setUserId(userId)
@@ -509,7 +590,7 @@ function _InternalPurchases(o = {} as object) as object
             "X-Platform": "roku",
             "X-Client-Bundle-ID": appInfo.GetID(),
             "X-Client-Version": appInfo.GetVersion(),
-            "X-Version": "0.0.2",
+            "X-Version": "0.1.0",
             "X-Platform-Version": deviceInfo.GetOSVersion(),
             "X-Storefront": deviceInfo.GetCountryCode(),
             "X-Is-Sandbox": appInfo.IsDev().ToStr(),
@@ -532,7 +613,7 @@ function _InternalPurchases(o = {} as object) as object
             return {
                 getCustomerInfo: m.getBaseUrl() + "subscribers/" + m.identityManager.appUserId(),
                 getOfferings: m.getBaseUrl() + "subscribers/" + m.identityManager.appUserId() + "/offerings"
-                postSubscriberAttributes: m.getBaseUrl() + "subscribers/" +  m.identityManager.appUserId() + "/attributes",
+                postSubscriberAttributes: m.getBaseUrl() + "subscribers/" + m.identityManager.appUserId() + "/attributes",
                 identify: m.getBaseUrl() + "subscribers/identify",
                 postReceipt: m.getBaseUrl() + "receipts",
             }
@@ -688,6 +769,89 @@ function _InternalPurchases(o = {} as object) as object
         registry: registry,
         configuration: configuration,
         identityManager: identityManager,
+        isSyncingPurchases: false,
+        maxReceiptPostAttempts: 5,
+        receiptPostQueueID: function(transaction as object) as string
+            if transaction.purchaseId <> invalid then return transaction.purchaseId
+            if transaction.purchase_id <> invalid then return transaction.purchase_id
+            if transaction.code <> invalid then return transaction.code + "_" + CreateObject("roDateTime").AsSeconds().ToStr()
+            return CreateObject("roDeviceInfo").getRandomUUID()
+        end function,
+        queueFailedReceiptPost: function(inputArgs as object) as void
+            m.registry.queueReceiptPost({
+                id: m.receiptPostQueueID(inputArgs.transaction),
+                userId: inputArgs.userId,
+                transaction: inputArgs.transaction,
+                presentedOfferingContext: inputArgs.presentedOfferingContext,
+            })
+        end function,
+        postReceiptWithRetryQueue: function(inputArgs = {}) as object
+            result = m.api.postReceipt(inputArgs)
+            if result.error <> invalid
+                m.queueFailedReceiptPost(inputArgs)
+            end if
+            return result
+        end function,
+        drainReceiptPostQueue: function(inputArgs = {}) as object
+            m.configuration.assert()
+            m.registry.purgeExpiredQueuedReceiptPosts()
+            queuedReceiptPosts = m.registry.getQueuedReceiptPosts()
+            failures = []
+            postedCount = 0
+
+            for each id in queuedReceiptPosts
+                entry = queuedReceiptPosts[id]
+                if entry.attempts = invalid then entry.attempts = 0
+                if entry.attempts >= m.maxReceiptPostAttempts
+                    failures.push(entry)
+                else
+                    entry.attempts++
+                    entry.lastAttemptAtMs = CreateObject("roDateTime").AsSeconds() * 1000&
+                    m.registry.updateQueuedReceiptPost(entry)
+
+                    result = m.api.postReceipt({
+                        userId: entry.userId,
+                        transaction: entry.transaction,
+                        presentedOfferingContext: entry.presentedOfferingContext,
+                    })
+
+                    if result.error = invalid
+                        postedCount++
+                        m.registry.removeQueuedReceiptPost(id)
+                    else
+                        failures.push(entry)
+                    end if
+                end if
+            end for
+
+            if failures.Count() > 0
+                return {
+                    data: {
+                        postedQueuedReceipts: postedCount,
+                        failedQueuedReceipts: failures,
+                    },
+                    error: {
+                        code: m.errors.configurationError.code,
+                        message: "One or more queued receipt posts failed.",
+                    }
+                }
+            end if
+
+            return {
+                data: {
+                    postedQueuedReceipts: postedCount,
+                    failedQueuedReceipts: [],
+                }
+            }
+        end function,
+        autoSyncPurchases: function(inputArgs = {}) as object
+            queueResult = m.drainReceiptPostQueue()
+            syncResult = m.syncPurchases({ isAutoSync: true })
+            if queueResult.error <> invalid
+                return queueResult
+            end if
+            return syncResult
+        end function,
         logIn: function(userId as string) as object
             m.configuration.assert()
             if userId = invalid or userId = ""
@@ -798,7 +962,7 @@ function _InternalPurchases(o = {} as object) as object
 
             transactions = result.data
 
-            result = m.api.postReceipt({
+            result = m.postReceiptWithRetryQueue({
                 userId: m.identityManager.appUserId(),
                 transaction: transactions[0],
                 presentedOfferingContext: presentedOfferingContext,
@@ -815,20 +979,46 @@ function _InternalPurchases(o = {} as object) as object
         end function,
         syncPurchases: function(inputArgs = {}) as object
             m.configuration.assert()
+            if m.isSyncingPurchases
+                _PurchasesLogger().info("syncPurchases already in progress")
+                return m.getCustomerInfo()
+            end if
+            m.isSyncingPurchases = true
             result = m.billing.getAllPurchases()
             if result.error <> invalid
+                m.isSyncingPurchases = false
                 return result
             end if
             allPurchases = result.data
+            failures = []
+            postedCount = 0
             for each purchase in allPurchases
-                result = m.api.postReceipt({
+                result = m.postReceiptWithRetryQueue({
                     userId: m.identityManager.appUserId(),
                     transaction: purchase,
                 })
                 if result.error <> invalid
-                    return result
+                    failures.push({
+                        transaction: purchase,
+                        error: result.error,
+                    })
+                else
+                    postedCount++
                 end if
             end for
+            m.isSyncingPurchases = false
+            if failures.Count() > 0
+                return {
+                    data: {
+                        postedPurchases: postedCount,
+                        failedPurchases: failures,
+                    },
+                    error: {
+                        code: m.errors.configurationError.code,
+                        message: "One or more purchases could not be synced.",
+                    }
+                }
+            end if
             return m.getCustomerInfo()
         end function,
         getOfferings: function(inputArgs = {}) as object
@@ -950,7 +1140,7 @@ function _InternalPurchases(o = {} as object) as object
                 })
             }
         end sub,
-        _deepCopy: function(original as Object) as Object
+        _deepCopy: function(original as object) as object
             if original = invalid then
                 return invalid
             end if

--- a/source/tests/Configuration.test.brs
+++ b/source/tests/Configuration.test.brs
@@ -26,6 +26,58 @@ function ConfigurationTests(t)
             end sub)
         end sub)
 
+        t.it("Auto syncs purchases on configure by default", sub(t)
+            billing = {
+                getAllPurchasesCount: 0,
+                getAllPurchases: function()
+                    m.getAllPurchasesCount++
+                    return { data: purchaseHistoryFixture() }
+                end function,
+            }
+            configurePurchases({ t: t, billing: billing })
+            clearConfiguration()
+
+            Purchases().configure({ apiKey: Constants().TEST_API_KEY })
+
+            t.assert.equal(internalTestPurchases().billing.getAllPurchasesCount, 1, "Expected auto sync to fetch purchases")
+        end sub)
+
+        t.it("Can disable auto sync purchases on configure", sub(t)
+            billing = {
+                getAllPurchasesCount: 0,
+                getAllPurchases: function()
+                    m.getAllPurchasesCount++
+                    return { data: purchaseHistoryFixture() }
+                end function,
+            }
+            configurePurchases({ t: t, billing: billing })
+            clearConfiguration()
+
+            Purchases().configure({ apiKey: Constants().TEST_API_KEY, autoSyncPurchases: false })
+
+            t.assert.equal(internalTestPurchases().billing.getAllPurchasesCount, 0, "Expected auto sync to be disabled")
+        end sub)
+
+        t.it("Auto sync failures do not break configure", sub(t)
+            api = {
+                postReceipt: function(inputArgs = {})
+                    return {
+                        error: {
+                            code: 500,
+                            message: "Server error",
+                        }
+                    }
+                end function,
+            }
+            configurePurchases({ t: t, api: api })
+            clearConfiguration()
+
+            Purchases().configure({ apiKey: Constants().TEST_API_KEY })
+
+            t.assert.isTrue(Purchases().isConfigured(), "Expected configured")
+            t.assert.isTrue(_PurchasesLogger().hasLoggedMessage("Auto sync purchases failed"), "Expected auto sync failure to be logged")
+        end sub)
+
         t.it("Throws assertion if used before configuring", sub(t)
             clearConfiguration()
 

--- a/source/tests/Offerings.test.brs
+++ b/source/tests/Offerings.test.brs
@@ -89,7 +89,7 @@ function OfferingsTests(t)
                 m.t.assert.isInvalid(error, "Unexpected error")
                 m.t.assert.isValid(offerings, "Offerings data error")
 
-                    ' Inject a fallback offering id, and a placement whose offering id does not exist
+                ' Inject a fallback offering id, and a placement whose offering id does not exist
                 offerings._placements.fallback_offering_id = "marks-premium"
                 offerings._placements.offering_ids_by_placement["valid_placement"] = "invalid_offering"
                 ' The valid placement should still return a valid offering

--- a/source/tests/Purchase.test.brs
+++ b/source/tests/Purchase.test.brs
@@ -74,6 +74,81 @@ function PurchaseTests(t)
                 m.t.assert.isValid(transaction, "Transaction error")
             end sub)
         end sub)
+
+        t.it("Queues failed receipt posts and drains them on configure", sub(t)
+            api = mockApi()
+            api.shouldFailPostReceipt = true
+            api.postReceiptCallCount = 0
+            api.postReceipt = function(inputArgs = {}) as object
+                m.postReceiptCallCount++
+                if m.shouldFailPostReceipt
+                    return {
+                        error: {
+                            code: 500,
+                            message: "Server error",
+                        }
+                    }
+                end if
+                return {
+                    data: subscriberFixture()
+                }
+            end function
+            configurePurchases({ t: t, api: api })
+            Purchases().logIn("mark_roku_test", sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+            end sub)
+
+            Purchases().purchase({ code: "product_id" }, sub(data, error)
+                m.t.assert.isValid(error, "Expected purchase receipt post error")
+                m.t.assert.equal(internalTestPurchases().registry.getQueuedReceiptPosts().Count(), 1, "Expected queued receipt post")
+            end sub)
+
+            internalTestPurchases().api.shouldFailPostReceipt = false
+            clearConfiguration()
+            Purchases().configure({ apiKey: Constants().TEST_API_KEY })
+
+            t.assert.equal(internalTestPurchases().registry.getQueuedReceiptPosts().Count(), 0, "Expected queued receipt post to drain")
+        end sub)
+
+        t.it("Continues syncing purchases after a receipt post fails", sub(t)
+            purchaseItems = [
+                { code: "first_product", purchaseId: "first_purchase" },
+                { code: "failed_product", purchaseId: "failed_purchase" },
+                { code: "third_product", purchaseId: "third_purchase" },
+            ]
+            billing = {
+                getAllPurchases: function()
+                    return { data: m.purchases }
+                end function,
+                purchases: purchaseItems,
+            }
+            api = mockApi()
+            api.postedCodes = []
+            api.postReceipt = function(inputArgs = {}) as object
+                m.postedCodes.push(inputArgs.transaction.code)
+                if inputArgs.transaction.code = "failed_product"
+                    return {
+                        error: {
+                            code: 500,
+                            message: "Server error",
+                        }
+                    }
+                end if
+                return {
+                    data: subscriberFixture()
+                }
+            end function
+            configurePurchases({ t: t, billing: billing, api: api })
+
+            Purchases().syncPurchases(sub(data, error)
+                m.t.assert.isValid(error, "Expected aggregate sync error")
+                m.t.assert.isValid(data, "Expected aggregate sync data")
+                m.t.assert.equal(data.postedPurchases, 2, "Expected two successful posts")
+                m.t.assert.equal(data.failedPurchases.Count(), 1, "Expected one failed post")
+                m.t.assert.equal(internalTestPurchases().api.postedCodes.Count(), 3, "Expected all purchases to be attempted")
+                m.t.assert.equal(internalTestPurchases().registry.getQueuedReceiptPosts().Count(), 1, "Expected failed receipt to be queued")
+            end sub)
+        end sub)
     end sub)
 end function
 

--- a/source/tests/roca/roca_lib.brs
+++ b/source/tests/roca/roca_lib.brs
@@ -316,17 +316,17 @@ function __case_execute()
     end if
 end function
 
-function __case_report(index as integer, tap as object) as string
+function __case_report(index as integer, tapInstance as object) as string
     if m.mode = "skip" or m.__state.success = invalid then
-        tap.skip(index, m.description)
+        tapInstance.skip(index, m.description)
         return "skipped"
     end if
 
     if m.__state.success = true then
-        tap.pass(index, m.description)
+        tapInstance.pass(index, m.description)
         return "passed"
     else if m.__state.success = false then
-        tap.fail(index, m.description, m.__state.metadata)
+        tapInstance.fail(index, m.description, m.__state.metadata)
         return "failed"
     end if
 end function
@@ -396,9 +396,9 @@ sub __suite_exec(args as object)
         m.__filterFocused()
     end if
 
-    tap = args.tap
-    tap.enterSubTest(m.__state.description)
-    tap.plan(m.__state.suites.count() + m.__state.cases.count())
+    tapInstance = args.tap
+    tapInstance.enterSubTest(m.__state.description)
+    tapInstance.plan(m.__state.suites.count() + m.__state.cases.count())
 
     subTestIndex = 0
     for each suite in m.__state.suites
@@ -411,15 +411,15 @@ sub __suite_exec(args as object)
 
         subTestIndex++
     end for
-    tap.exitSubTest()
+    tapInstance.exitSubTest()
 
     index = subTestIndex
     for each case in m.__state.cases
-        tap.indent()
+        tapInstance.indent()
         if case.mode <> "skip" and m.mode <> "skip" and m.__state.hasSkippedAncestors <> true then
             case.exec()
         end if
-        result = case.report(index, tap)
+        result = case.report(index, tapInstance)
         if result = "passed" then
             m.__state.results.passed++
         else if result = "failed" then
@@ -427,7 +427,7 @@ sub __suite_exec(args as object)
         else
             m.__state.results.skipped++
         end if
-        tap.deindent()
+        tapInstance.deindent()
 
         index++
     end for
@@ -437,9 +437,9 @@ sub __suite_exec(args as object)
     ' ignore skipped tests as part of suite completion -- as long as the suite doesn't fail, it's
     ' basically a success
     if results.failed > 0 then
-        tap.fail(args.index, description)
+        tapInstance.fail(args.index, description)
     else
-        tap.pass(args.index, description)
+        tapInstance.pass(args.index, description)
     end if
 
     ' we may have changed context during execution, so let's update our parent's context

--- a/source/tests/testUtils.brs
+++ b/source/tests/testUtils.brs
@@ -24,6 +24,9 @@ function configurePurchases(inputArgs = {} as object)
             return { data: purchasedTransactionFixture() }
         end function,
     }
+    if inputArgs.billing <> invalid
+        billing = inputArgs.billing
+    end if
 
     _InternalPurchases_SetPurchasesConfig({
         apiKey: Constants().TEST_API_KEY

--- a/source/tests/test_fixtures.brs
+++ b/source/tests/test_fixtures.brs
@@ -405,33 +405,33 @@ function offeringsFixture(inputArgs = {}) as object
     return {
         "current_offering_id": "marks-premium",
         "offerings": [
-          {
-            "description": "default",
-            "identifier": "marks-premium",
-            "metadata": {
-              "foo": "bar"
-            },
-            "packages": [
-              {
-                "identifier": "$rc_monthly",
-                "platform_product_identifier": "monthly_product"
-              },
-              {
-                "identifier": "$rc_annual",
-                "platform_product_identifier": "yearly_subscription_product"
-              }
-            ]
-          }
+            {
+                "description": "default",
+                "identifier": "marks-premium",
+                "metadata": {
+                    "foo": "bar"
+                },
+                "packages": [
+                    {
+                        "identifier": "$rc_monthly",
+                        "platform_product_identifier": "monthly_product"
+                    },
+                    {
+                        "identifier": "$rc_annual",
+                        "platform_product_identifier": "yearly_subscription_product"
+                    }
+                ]
+            }
         ],
         "placements": {
-          "fallback_offering_id": invalid,
-          "offering_ids_by_placement": {
-            "my_placement": "marks-premium"
-          }
+            "fallback_offering_id": invalid,
+            "offering_ids_by_placement": {
+                "my_placement": "marks-premium"
+            }
         },
         "targeting": {
-          "revision": 10,
-          "rule_id": "AK_1qeJfjN"
+            "revision": 10,
+            "rule_id": "AK_1qeJfjN"
         }
-      }
+    }
 end function


### PR DESCRIPTION
## Summary
- Automatically sync Roku purchases after `Purchases().configure(...)` by default
- Add an `autoSyncPurchases: false` opt-out for apps that need to disable launch-time syncing
- Persist failed receipt posts in a registry-backed retry queue and retry them on later SDK startup
- Continue processing remaining purchases when one receipt post fails, returning aggregate failure information
- Bump the SDK version to 0.1.0 and document the behavior change

## Why
The previous Roku SDK behavior depended on developers explicitly calling `syncPurchases`, posted each receipt only once, and stopped processing after the first receipt failure. That could leave valid Roku purchases unsynced after an out-of-app purchase or a transient network/API failure.

## Validation
- `corepack yarn tests`
- `corepack yarn lint`
- `corepack yarn checkFormat`

## Rollout Notes
This is a behavior change because purchase syncing now runs automatically after configure. Apps can opt out with `autoSyncPurchases: false`.