### PR TITLE
Sync Roku customer ID as a subscriber attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Initialize the SDK with your api key. You typically do this inside the `init()` 
   end sub
 ```
 
+When Roku transaction data includes `rokuCustomerId`, the SDK syncs it to RevenueCat as the reserved subscriber attribute `$rokuCustomerId`. This can happen after a purchase or when `syncPurchases` reads existing Roku purchase history. Users without Roku Pay purchase history are not expected to have this attribute.
+
 ## Callbacks and error handling
 
 In methods of the SDK which perform async operations, you can get the result by passing a sub routine or a callback name.

--- a/source/Purchases.brs
+++ b/source/Purchases.brs
@@ -757,6 +757,61 @@ function _InternalPurchases(o = {} as object) as object
             end if
             return { data: true }
         end function,
+        rokuCustomerIDAttributeKey: "$rokuCustomerId",
+        rokuCustomerIDAttributeSyncsKey: "rokuCustomerIDAttributeSyncs",
+        rokuCustomerIDFromTransaction: function(transaction as object) as object
+            if transaction = invalid then return invalid
+            rokuCustomerID = transaction.rokuCustomerId
+            if rokuCustomerID = invalid then rokuCustomerID = transaction.roku_customer_id
+            if rokuCustomerID = invalid then rokuCustomerID = transaction.customerId
+            valueType = type(rokuCustomerID)
+            if (valueType = "roString" or valueType = "String") and rokuCustomerID <> "" then return rokuCustomerID
+            return invalid
+        end function,
+        rokuCustomerIDFromTransactions: function(transactions as object) as object
+            if transactions = invalid then return invalid
+            for each transaction in transactions
+                rokuCustomerID = m.rokuCustomerIDFromTransaction(transaction)
+                if rokuCustomerID <> invalid then return rokuCustomerID
+            end for
+            return invalid
+        end function,
+        hasSyncedRokuCustomerIDAttribute: function(userID as string, rokuCustomerID as string) as boolean
+            entries = m.registry.get()
+            syncs = entries[m.rokuCustomerIDAttributeSyncsKey]
+            if type(syncs) <> "roAssociativeArray" then return false
+            return syncs[userID] = rokuCustomerID
+        end function,
+        setSyncedRokuCustomerIDAttribute: function(userID as string, rokuCustomerID as string) as void
+            entries = m.registry.get()
+            syncs = entries[m.rokuCustomerIDAttributeSyncsKey]
+            if type(syncs) <> "roAssociativeArray" then syncs = {}
+            syncs[userID] = rokuCustomerID
+            update = {}
+            update[m.rokuCustomerIDAttributeSyncsKey] = syncs
+            m.registry.set(update)
+        end function,
+        syncRokuCustomerIDAttributeFromTransactions: function(transactions as object) as object
+            rokuCustomerID = m.rokuCustomerIDFromTransactions(transactions)
+            if rokuCustomerID = invalid then return { data: false }
+
+            userID = m.identityManager.appUserId()
+            if m.hasSyncedRokuCustomerIDAttribute(userID, rokuCustomerID) then return { data: false }
+
+            attributes = {}
+            attributes[m.rokuCustomerIDAttributeKey] = rokuCustomerID
+            result = m.api.postSubscriberAttributes({
+                userId: userID,
+                attributes: attributes,
+            })
+            if result.error <> invalid
+                _PurchasesLogger().warn("Failed to sync Roku customer ID subscriber attribute")
+                _PurchasesLogger().warn(result.error)
+                return result
+            end if
+            m.setSyncedRokuCustomerIDAttribute(userID, rokuCustomerID)
+            return { data: true }
+        end function,
         purchase: function(inputArgs = {}) as object
             m.configuration.assert()
             code = ""
@@ -798,6 +853,7 @@ function _InternalPurchases(o = {} as object) as object
 
             transactions = result.data
 
+            m.syncRokuCustomerIDAttributeFromTransactions(transactions)
             result = m.api.postReceipt({
                 userId: m.identityManager.appUserId(),
                 transaction: transactions[0],
@@ -820,6 +876,7 @@ function _InternalPurchases(o = {} as object) as object
                 return result
             end if
             allPurchases = result.data
+            m.syncRokuCustomerIDAttributeFromTransactions(allPurchases)
             for each purchase in allPurchases
                 result = m.api.postReceipt({
                     userId: m.identityManager.appUserId(),

--- a/source/tests/Purchase.test.brs
+++ b/source/tests/Purchase.test.brs
@@ -74,6 +74,140 @@ function PurchaseTests(t)
                 m.t.assert.isValid(transaction, "Transaction error")
             end sub)
         end sub)
+
+        t.it("Syncs Roku customer ID as a reserved subscriber attribute after purchase", sub(t)
+            Purchases().purchase({ code: "product_id" }, sub(data, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+                attributes = internalTestPurchases().api.postSubscriberAttributesInputArgs.attributes
+                m.t.assert.equal(attributes["$rokuCustomerId"], data.transaction.rokuCustomerId, "Unexpected Roku customer ID attribute")
+            end sub)
+        end sub)
+
+        t.it("Syncs the first Roku customer ID as a reserved subscriber attribute during syncPurchases", sub(t)
+            purchaseItems = [
+                { code: "first_product", purchaseId: "first_purchase" },
+                { code: "second_product", purchaseId: "second_purchase", rokuCustomerId: "roku_customer_id" },
+                { code: "third_product", purchaseId: "third_purchase", rokuCustomerId: "different_roku_customer_id" },
+            ]
+            api = mockApi()
+            api.postSubscriberAttributesCallCount = 0
+            api.postSubscriberAttributes = function(inputArgs = {})
+                m.postSubscriberAttributesCallCount++
+                m.postSubscriberAttributesInputArgs = inputArgs
+                return { data: true }
+            end function
+            configurePurchases({ t: t, api: api })
+            internalTestPurchases().billing.purchases = purchaseItems
+            internalTestPurchases().billing.getAllPurchases = function()
+                return { data: m.purchases }
+            end function
+
+            Purchases().syncPurchases(sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+                m.t.assert.equal(internalTestPurchases().api.postSubscriberAttributesCallCount, 1, "Expected one subscriber attribute update")
+                attributes = internalTestPurchases().api.postSubscriberAttributesInputArgs.attributes
+                m.t.assert.equal(attributes["$rokuCustomerId"], "roku_customer_id", "Unexpected Roku customer ID attribute")
+            end sub)
+        end sub)
+
+        t.it("Skips Roku customer ID sync when purchase data does not include a valid string ID", sub(t)
+            api = mockApi()
+            api.postSubscriberAttributesCallCount = 0
+            api.postSubscriberAttributes = function(inputArgs = {})
+                m.postSubscriberAttributesCallCount++
+                m.postSubscriberAttributesInputArgs = inputArgs
+                return { data: true }
+            end function
+            configurePurchases({ t: t, api: api })
+
+            result = internalTestPurchases().syncRokuCustomerIDAttributeFromTransactions([])
+            m.t.assert.isFalse(result.data, "Expected empty purchases to skip attribute sync")
+
+            result = internalTestPurchases().syncRokuCustomerIDAttributeFromTransactions([
+                { rokuCustomerId: "" },
+                { rokuCustomerId: 12345 },
+                { rokuCustomerId: false },
+                {},
+            ])
+            m.t.assert.isFalse(result.data, "Expected invalid Roku customer IDs to skip attribute sync")
+            m.t.assert.equal(internalTestPurchases().api.postSubscriberAttributesCallCount, 0, "Expected no subscriber attribute updates")
+        end sub)
+
+        t.it("Does not sync duplicate Roku customer ID attributes for the same app user ID", sub(t)
+            purchaseItems = [
+                { code: "product", purchaseId: "purchase", rokuCustomerId: "roku_customer_id" },
+            ]
+            api = mockApi()
+            api.postSubscriberAttributesCallCount = 0
+            api.postSubscriberAttributes = function(inputArgs = {})
+                m.postSubscriberAttributesCallCount++
+                m.postSubscriberAttributesInputArgs = inputArgs
+                return { data: true }
+            end function
+            configurePurchases({ t: t, api: api })
+            internalTestPurchases().billing.purchases = purchaseItems
+            internalTestPurchases().billing.getAllPurchases = function()
+                return { data: m.purchases }
+            end function
+
+            Purchases().syncPurchases(sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+            end sub)
+            Purchases().syncPurchases(sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+                m.t.assert.equal(internalTestPurchases().api.postSubscriberAttributesCallCount, 1, "Expected one subscriber attribute update")
+            end sub)
+        end sub)
+
+        t.it("Re-syncs Roku customer ID attributes after the app user ID changes", sub(t)
+            purchaseItems = [
+                { code: "product", purchaseId: "purchase", rokuCustomerId: "roku_customer_id" },
+            ]
+            api = mockApi()
+            api.postSubscriberAttributesCallCount = 0
+            api.postSubscriberAttributes = function(inputArgs = {})
+                m.postSubscriberAttributesCallCount++
+                m.postSubscriberAttributesInputArgs = inputArgs
+                return { data: true }
+            end function
+            configurePurchases({ t: t, api: api })
+            internalTestPurchases().billing.purchases = purchaseItems
+            internalTestPurchases().billing.getAllPurchases = function()
+                return { data: m.purchases }
+            end function
+
+            Purchases().syncPurchases(sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+            end sub)
+            Purchases().logIn("different_user", sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+            end sub)
+            Purchases().syncPurchases(sub(subscriber, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+                m.t.assert.equal(internalTestPurchases().api.postSubscriberAttributesCallCount, 2, "Expected subscriber attribute update after app user ID change")
+                m.t.assert.equal(internalTestPurchases().api.postSubscriberAttributesInputArgs.userId, "different_user", "Unexpected subscriber attribute user ID")
+            end sub)
+        end sub)
+
+        t.it("Does not fail purchase when Roku customer ID attribute sync fails", sub(t)
+            api = mockApi()
+            api.postSubscriberAttributes = function(inputArgs = {}) as object
+                m.postSubscriberAttributesInputArgs = inputArgs
+                return {
+                    error: {
+                        code: 500,
+                        message: "Server error",
+                    }
+                }
+            end function
+            configurePurchases({ t: t, api: api })
+
+            Purchases().purchase({ code: "product_id" }, sub(data, error)
+                m.t.assert.isInvalid(error, "Unexpected error")
+                m.t.assert.isValid(data, "Expected purchase data")
+                m.t.assert.isTrue(_PurchasesLogger().hasLoggedMessage("Failed to sync Roku customer ID subscriber attribute"), "Expected warning log")
+            end sub)
+        end sub)
     end sub)
 end function
 


### PR DESCRIPTION
## Summary
- Read Roku `rokuCustomerId` values from Roku Pay transaction data when available
- Sync the value to RevenueCat as the reserved subscriber attribute `$rokuCustomerId`
- Run the attribute sync after a successful purchase and when `syncPurchases` reads existing Roku purchase history
- Set the attribute once from the first purchase record that includes a Roku customer ID
- Cache successful syncs by app user ID and Roku customer ID to avoid redundant subscriber attribute POSTs
- Keep purchase and sync flows non-blocking if the subscriber attribute update fails
- Document the reserved attribute behavior and add regression coverage

## Why
Roku returns `rokuCustomerId` with Roku Pay transaction data. Syncing it as a reserved subscriber attribute gives support and internal tooling another stable customer handle for purchasers without changing the purchase flow.

This attribute is only set when Roku transaction data includes `rokuCustomerId`, such as after a purchase or when syncing existing purchases. Users without Roku Pay purchase history are not expected to have this attribute.

## Validation
- `corepack yarn tests`
- `git diff --check`

## Compatibility Notes
The attribute update is best-effort. Receipt posting and purchase sync continue even if the `$rokuCustomerId` attribute update fails. Successful syncs are cached per app user ID, so identity changes still allow the same Roku customer ID to sync for the new subscriber.