### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS for purchases-roku
+
+# Default owners
+* @RevenueCat/sdk


### PR DESCRIPTION
Add missing CODEOWNERS file to automatically ping the SDK team on PRs